### PR TITLE
FixTreeNodeClickNotAlignWithUserView

### DIFF
--- a/src/Outline.vue
+++ b/src/Outline.vue
@@ -41,6 +41,7 @@ import { marked } from 'marked';
 import { formula, internal_link, highlight, tag, remove_href, renderer, remove_ref, nolist } from './parser';
 import { store } from './store';
 import { QuietOutline } from "./plugin";
+import { lineJump, resetLineJump } from "./plugin";
 
 const lightThemeConfig = reactive<GlobalThemeOverrides>({
     common: {
@@ -205,6 +206,12 @@ function _handleScroll(evt: Event) {
 
     // @ts-ignore
     let current_line = view.currentMode.getScroll() + 8;
+
+	if (lineJump != null) {
+		current_line = lineJump;
+		resetLineJump();
+	}
+
     let current_heading = null;
 
     let i = store.headers.length;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -193,9 +193,14 @@ export class QuietOutline extends Plugin {
 }
 export function dummyJump(plugin: QuietOutline, key: number) {}
 
+export let lineJump: number;
+export function resetLineJump() {
+	lineJump = null;
+}
+
 function markdownJump(plugin: QuietOutline, key: number) {
     let line: number = store.headers[key].position.start.line;
-
+	lineJump = line;
     // const view = store.plugin.app.workspace.getActiveViewOfType(MarkdownView)
     const view = plugin.current_note;
     if (view) {


### PR DESCRIPTION
due to scalling or my window setting or the mouse scroll value it result in 

(when i debug i found that my current_line jump all over the place and cause this)

<img width="352" alt="Screenshot 2023-11-06 014112" src="https://github.com/guopenghui/obsidian-quiet-outline/assets/113448161/ac50c3d4-4bc6-498e-b271-1979ee76db1d">

- when i click some heading, example the MVC heading it highlight the heading above or sometime the heading bellow