### PR TITLE
fix: disabling "Render Markdown" causes "Keep one line per title" to …

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,7 @@
   line-height: 1.6em;
   min-height: 10px;
 }
+.quiet-outline .n-tree.ellipsis .n-tree-node .n-tree-node-content div,
 .quiet-outline .n-tree-node-content__text p {
   margin: 0;
 }


### PR DESCRIPTION
问题：当禁用“渲染markdown元素”后，启用“省略长标题”时不会生效（主要是中文标题受影响）
原因：自己初步查看好像是禁用“渲染markdown元素”，会导致渲染得到的节点是 div 而不是 p（如图）
解决：加上选择器：.quiet-outline .n-tree.ellipsis .n-tree-node .n-tree-node-content div

![](https://github.com/guopenghui/obsidian-quiet-outline/assets/102728558/f739f252-b7d9-4356-b5ed-c8c0af1518b8)
![](https://github.com/guopenghui/obsidian-quiet-outline/assets/102728558/13b79a89-4d8f-44f3-b1c5-811dc97c5727)



