### PR TITLE
fix: disabling "Render Markdown" causes "Keep one line per title" to fail

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,7 @@
 .quiet-outline .n-tree.ellipsis {
   overflow-x: hidden;
 }
+.quiet-outline .n-tree.ellipsis .n-tree-node .n-tree-node-content div,
 .quiet-outline .n-tree.ellipsis .n-tree-node .n-tree-node-content p {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
问题：当禁用“渲染markdown元素”后，启用“省略长标题”时不会生效（主要是中文标题受影响）
原因：自己初步查看好像是禁用“渲染markdown元素”，会导致渲染得到的节点是 div 而不是 p（如图）
解决：加上选择器：.quiet-outline .n-tree.ellipsis .n-tree-node .n-tree-node-content div

![](https://github.com/guopenghui/obsidian-quiet-outline/assets/102728558/dbcb2d7a-8e80-49b3-b309-9b507b4a498d)
![](https://github.com/guopenghui/obsidian-quiet-outline/assets/102728558/79212914-a29a-419c-a6f8-c29571e475ec)

