### PR TITLE
Fix ellipsis blurring issue of stalin.css

### DIFF
--- a/src/stalin.css
+++ b/src/stalin.css
@@ -22,7 +22,9 @@
 }
 
 .quiet-outline .n-tree-node-content__text p {
-    margin: 0;
+  line-height: 1.2em; /* 调整原始段落行距 */
+  margin-top: 2.6px;  /* 微调段落上方的间距使与改line-height前一致 */
+  margin-bottom: 2.6px;  /* 微调段落下方的间距使与改line-height前一致 */
 }
 
 /* ellipsis */


### PR DESCRIPTION
关闭ellipsis功能后，显示的多行标题的行间距，与两个标题之间的行间距一致，导致难以直接区分一个标题的行 还是一个多行标题。

通过该css样式修改，减小标题内部多行文本之间的行距，并通过补偿两个标题之间的行间距使其与原来一样。最终使得两个多行标题更容易区分。

**在关闭Ellipsis时**，多行标题已启用，本修改减少了多行标题内部行之间的空隙，**使得两个多行标题更容易区分**。
修改前(关闭Ellipsis):
![image](https://github.com/user-attachments/assets/dbaf6e27-6b26-4bb4-b780-08e3eda853ac)

修改后(关闭Ellipsis):
![image](https://github.com/user-attachments/assets/bf93ed02-f3c9-4231-8167-e632e082fdb0)

**在启用Ellipsis时**，**本修改没有任何影响**。
修改前(启用Ellipsis)：
![72f5e621c39f46cec6ea4d6603a9100](https://github.com/user-attachments/assets/1e698067-1383-4f53-8dd5-7aeee62c5b7e)

修改后(启用Ellipsis):
![72f5e621c39f46cec6ea4d6603a9100](https://github.com/user-attachments/assets/f7c5f1d3-aa15-469c-b591-1975743f10df)

**计算公式：**
 * 注明：电脑上测试字体大小是13px
 * 补偿计算：
	13px * 1.6 = 原始行高像素值； 
	(13px * 1.6 -13px)/2 = 原始单侧空白；
	13px * line-height = 新行高的像素值；
	(13px * line-height - 13px)/2 = 新单侧空白；
	原始单侧空白 - 新单侧空白 = 损失的单侧空白 = margin-top = margin-bottom；
当 line-height 调整为1.2em时，计算得margin-top = margin-bottom = 2.6px。

