### PR TITLE
feat: Added canvas outline sorting options and translation.

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -46,6 +46,12 @@ export default {
 
     "Export Format": "Export Format",
 
+    "Canvas Sort Order": "Canvas Sort Order",
+    "Sort method for canvas nodes": "Sort method for canvas nodes",
+    "Sort by Area": "Sort by Area (Big -> Small)",
+    "Sort by Name (A -> Z)": "Sort by Name (A -> Z)",
+    "Sort by Name (Z -> A)": "Sort by Name (Z -> A)",
+
     // menu
     "Copy": "Copy",
     "Heading": "Heading",

--- a/src/lang/locale/zh-TW.ts
+++ b/src/lang/locale/zh-TW.ts
@@ -45,6 +45,11 @@ export default {
     "is decided by": "由什麼決定",
 
     "Export Format": "標題輸出格式",
+    "Canvas Sort Order": "白板大綱排序",
+    "Sort method for canvas nodes": "白板卡片的排序邏輯",
+    "Sort by Area": "按面積 (大 -> 小)",
+    "Sort by Name (A -> Z)": "按名稱 (A -> Z)",
+    "Sort by Name (Z -> A)": "按名稱 (Z -> A)",
 
     // menu
     "Copy": "複製",

--- a/src/lang/locale/zh.ts
+++ b/src/lang/locale/zh.ts
@@ -47,6 +47,12 @@ export default {
 
     "Export Format": "标题输出格式",
 
+    "Canvas Sort Order": "白板大纲排序",
+    "Sort method for canvas nodes": "白板卡片的排序逻辑",
+    "Sort by Area": "按面积 (大 -> 小)",
+    "Sort by Name (A -> Z)": "按名称 (A -> Z)",
+    "Sort by Name (Z -> A)": "按名称 (Z -> A)",
+
     // menu
     "Copy": "复制",
     "Heading": "标题",

--- a/src/navigators/canvas.ts
+++ b/src/navigators/canvas.ts
@@ -118,7 +118,7 @@ export class CanvasNav extends Nav {
         const nodes = this.view.canvas.data.nodes as AllCanvasNodeData[];
         // nodes may be undefined when switch to canvas view
         if (nodes) {
-            return canvasNodesToHeaders(nodes);
+            return canvasNodesToHeaders(nodes, this.plugin.settings.canvas_sort_by);
         }
         return [];
     }
@@ -161,9 +161,22 @@ export class CanvasNav extends Nav {
     }
 }
 
-function canvasNodesToHeaders(nodes: AllCanvasNodeData[]): Heading[] {
+function canvasNodesToHeaders(
+    nodes: AllCanvasNodeData[], 
+    sortMode: "area" | "name_asc" | "name_desc" = "area"
+): Heading[] {
+    // 下行为原注释
     // const groups = nodes.filter(node => node.type === "group").sort((a, b) => - cmpArea(a, b));
-    const nodesDec = nodes.slice().sort((a, b) => -cmpArea(a, b));
+    const nodesDec = nodes.slice().sort((a, b) => {
+        if (sortMode === "name_asc") {
+            return text(a).localeCompare(text(b), undefined, { numeric: true });
+        }
+        if (sortMode === "name_desc") {
+            return text(b).localeCompare(text(a), undefined, { numeric: true });
+        }
+        // 默认按面积倒序
+        return -cmpArea(a, b);
+    });
 
     const trees: TreeNode[] = [];
     for (let i = 0; i < nodesDec.length; i++) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,6 +27,7 @@ interface QuietOutlineSettings {
     lang_direction_decide_by: "system" | "text";
     auto_scroll_into_view: boolean;
     vimlize_canvas: boolean;
+    canvas_sort_by: "area" | "name_asc" | "name_desc";
 
     // Style settings
     patch_color: boolean;
@@ -76,6 +77,7 @@ const DEFAULT_SETTINGS: QuietOutlineSettings = {
     lang_direction_decide_by: "system",
     auto_scroll_into_view: true,
     vimlize_canvas: true,
+    canvas_sort_by: "area",
 
     // Style settings
     patch_color: true,
@@ -360,6 +362,27 @@ class SettingTab extends PluginSettingTab {
                         this.plugin.settings.vimlize_canvas = value;
                         await this.plugin.saveSettings();
                     }),
+            );
+
+        new Setting(container)
+            .setName(t("Canvas Sort Order"))
+            .setDesc(t("Sort method for canvas nodes"))
+            .addDropdown((dropdown) =>
+                dropdown
+                    .addOption("area", t("Sort by Area"))
+                    .addOption("name_asc", t("Sort by Name (A -> Z)"))
+                    .addOption("name_desc", t("Sort by Name (Z -> A)"))
+                    .setValue(this.plugin.settings.canvas_sort_by)
+                    .onChange(
+                        async (
+                            value: "area" | "name_asc" | "name_desc",
+                        ) => {
+                            this.plugin.settings.canvas_sort_by = value;
+                            await this.plugin.saveSettings();
+                            // 触发刷新
+                            this.plugin.refresh(); 
+                        },
+                    ),
             );
 
         new Setting(container)


### PR DESCRIPTION
Added a setting option to customize the sorting logic of the Outline in Canvas mode.
**Problem:**
Currently, Canvas nodes are sorted by area size (width * height). When using Canvas for linear notes (e.g., daily logs or timelines) where cards have similar sizes, the outline order becomes chaotic and unpredictable.
**Solution:**
Added a "Canvas Sort Order" option in settings:
- Sort by Area (Default, maintains original behavior)
- Sort by Name (A -> Z)
- Sort by Name (Z -> A)

This ensures users can have a deterministic order for their notes in Canvas.
Included translations for English, Simplified Chinese, and Traditional Chinese.


让大纲更有序。
Before：
<img width="1102" height="587" alt="image" src="https://github.com/user-attachments/assets/1bfda133-1fd2-4e93-a730-306468405d36" />
after：
<img width="994" height="523" alt="image" src="https://github.com/user-attachments/assets/a37747e1-8266-4662-bc18-edc7a5389720" />
默认按大小排序，可选文件名逆序和正序。
<img width="759" height="185" alt="image" src="https://github.com/user-attachments/assets/5be8d6fc-8026-4827-ace5-4f1a719592e6" />
