### PR TITLE
[codex] Render inline callout icons in headings

### DIFF
--- a/src/stalin.css
+++ b/src/stalin.css
@@ -125,6 +125,33 @@
     margin: 0;
 }
 
+.quiet-outline .inline-callout {
+    display: inline-flex;
+    align-items: center;
+    margin: 0 4px 0 0;
+    padding: 0;
+    border-radius: var(--inline-callout-border-radius, 4px);
+    vertical-align: text-bottom;
+}
+
+.quiet-outline .inline-callout-icon {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+}
+
+.quiet-outline .inline-callout-icon svg {
+    width: var(--inline-callout-icon-size, .9em);
+    height: var(--inline-callout-icon-size, .9em);
+}
+
+.quiet-outline .inline-callout-label {
+    display: inline-flex;
+    align-items: center;
+    margin: 0 0 0 3px;
+    font-size: var(--inline-callout-font-size, .85em);
+}
+
 /* ellipsis */
 .quiet-outline .n-tree.ellipsis {
     overflow-x: hidden;

--- a/src/ui/use-heading-renderer.ts
+++ b/src/ui/use-heading-renderer.ts
@@ -4,6 +4,7 @@ import { sanitizeHTMLToDom } from "obsidian";
 import { marked } from "marked";
 import type QuietOutline from "@/plugin";
 import { store } from "@/store";
+import { postProcessInlineCallouts } from "@/utils/inline-callout";
 import { Icon } from "@vicons/utils";
 import { ArrowForwardIosRound, LocalIcon } from "./icons";
 import type { TreeOptionX } from "./types";
@@ -84,7 +85,15 @@ function mdToHtml(label: string | undefined) {
 
 function renderMarkdown({ option }: { option: TreeOption; }) {
     const result = mdToHtml(option.label);
-    return h("div", { innerHTML: result });
+    return h("div", {
+        innerHTML: result,
+        onVnodeMounted(vnode) {
+            postProcessInlineCallouts(vnode.el as HTMLElement);
+        },
+        onVnodeUpdated(vnode) {
+            postProcessInlineCallouts(vnode.el as HTMLElement);
+        },
+    });
 }
 
 // switch icon

--- a/src/ui/use-search.ts
+++ b/src/ui/use-search.ts
@@ -1,7 +1,8 @@
 import type { TreeOption } from "naive-ui";
 import { computed, ref } from "vue";
 import { store } from "@/store";
-import { escapeHtml, getOrigin, htmlToText } from "@/utils/html"
+import { escapeHtml, getOrigin, htmlToText } from "@/utils/html";
+import { replaceInlineCalloutsWithText } from "@/utils/inline-callout";
 import { marked } from "marked";
 
 export function useOutlineSearch() {
@@ -48,7 +49,7 @@ function simpleFilter(pattern: string, option: TreeOption): boolean {
  * @returns The textContent (**no sanitized!!!**)
  */
 function mdToHtmlTextContent(text: string | undefined) {
-    let result = marked.parse(text || "", { async: false }).trim();
+    let result = marked.parse(replaceInlineCalloutsWithText(text), { async: false }).trim();
 
     // save mjx elements
     let i = 0;
@@ -66,5 +67,5 @@ function mdToHtmlTextContent(text: string | undefined) {
         return mjxes[i++];
     });
 
-    return htmlToText(result)
+    return htmlToText(result);
 }

--- a/src/utils/inline-callout.ts
+++ b/src/utils/inline-callout.ts
@@ -1,0 +1,102 @@
+import { getIcon } from "obsidian";
+
+type InlineCallout = {
+    icon: string;
+    label?: string;
+    color?: string;
+};
+
+const INLINE_CALLOUT_CODE = /^\[!!(.+)\]$/;
+const INLINE_CALLOUT_CODE_SPAN = /`(\[!![^`\n]+\])`/g;
+
+export function postProcessInlineCallouts(el: HTMLElement) {
+    el.querySelectorAll("code").forEach((code) => {
+        const callout = createInlineCalloutElement(code.innerText.trim());
+        if (callout) {
+            code.replaceWith(callout);
+        }
+    });
+}
+
+export function replaceInlineCalloutsWithText(text: string | undefined) {
+    return (text || "").replace(INLINE_CALLOUT_CODE_SPAN, (_match, raw: string) => {
+        const parsed = parseInlineCallout(raw);
+        return parsed?.label || "";
+    });
+}
+
+function createInlineCalloutElement(raw: string) {
+    const callout = parseInlineCallout(raw);
+    if (!callout) return null;
+
+    const icon = getIcon(callout.icon) || getIcon(`lucide-${callout.icon}`);
+    if (!icon) return null;
+
+    const container = document.createElement("span");
+    const iconEl = document.createElement("span");
+    const labelEl = document.createElement("span");
+
+    container.addClass("inline-callout");
+    container.setAttr("data-inline-callout", callout.icon);
+    iconEl.addClass("inline-callout-icon");
+    iconEl.setAttr("data-tooltip-position", "top");
+    iconEl.setAttr("aria-label", callout.icon);
+    iconEl.appendChild(icon);
+    container.appendChild(iconEl);
+
+    if (callout.label) {
+        labelEl.addClass("inline-callout-label");
+        labelEl.setText(callout.label);
+        container.appendChild(labelEl);
+    }
+
+    applyColor(container, iconEl, callout);
+    return container;
+}
+
+function parseInlineCallout(raw: string): InlineCallout | null {
+    const match = INLINE_CALLOUT_CODE.exec(raw);
+    if (!match) return null;
+
+    const parts = match[1].split("|");
+    const icon = parts[0]?.trim().replace(/\\+$/, "").toLowerCase();
+    if (!icon) return null;
+
+    return {
+        icon,
+        label: cleanPart(parts[1]),
+        color: cleanPart(parts[2]),
+    };
+}
+
+function cleanPart(part: string | undefined) {
+    const clean = part?.trim().replace(/\\+$/, "");
+    return clean ? clean : undefined;
+}
+
+function applyColor(container: HTMLElement, iconEl: HTMLElement, callout: InlineCallout) {
+    if (!callout.color) return;
+
+    const color = calloutColor(callout.color);
+    if (!color) return;
+
+    if (callout.label) {
+        container.style.color = color;
+        container.style.backgroundColor = backgroundColor(callout.color);
+    } else {
+        iconEl.style.color = color;
+    }
+}
+
+function calloutColor(value: string) {
+    if (!isSafeColorValue(value)) return null;
+    return `rgba(${value}, 1)`;
+}
+
+function backgroundColor(value: string) {
+    return `rgba(${value}, var(--inline-callout-bg-transparency, .1))`;
+}
+
+function isSafeColorValue(value: string) {
+    return /^var\(--[\w-]+\)$/.test(value) || /^\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}$/.test(value);
+}


### PR DESCRIPTION
## Summary
- render Inline Callouts-style code spans in Quiet Outline heading labels
- keep invalid callout syntax as normal code
- make outline search ignore icon-only callouts and search labeled callouts by label text
- add scoped styles so rendered icons align inside tree rows

## Why
Quiet Outline already renders common Obsidian heading markdown, but headings that use inline-callout icon syntax display raw `[!!...]` code spans. This makes icon-heavy outlines difficult to scan.

## Validation
- `npm ci`
- `npm run check`
- `npm run lint`
- `npm run build`
- copied ignored build artifacts into a local Obsidian vault and reloaded `obsidian-quiet-outline`
- verified icon-only headings render SVG icons with no leftover `<code>` nodes
- verified labeled callouts render labels such as `Examples of Envy`
- verified clean Obsidian `dev:errors` and console after navigation/rendering
